### PR TITLE
Scroll administrar contenido

### DIFF
--- a/vista/app/src/components/AdministrarContenido.js
+++ b/vista/app/src/components/AdministrarContenido.js
@@ -42,9 +42,9 @@ class AdministrarContenido extends Component {
 
   render () {
     const {modalOpen} = this.state;
-    const {modalTitle, contenidoProps, FormElement, formElementProps} = this.props;
+    const {modalTitle, contenidoProps, FormElement, formElementProps, mostrarContenido} = this.props;
     return (
-      <div>
+      <div className={mostrarContenido !== "undefined" ? mostrarContenido ? 'show' : "hide" : ''}>
         <Contenido
           {...contenidoProps}
           onAgregar={this.toggleModal}

--- a/vista/app/src/components/AdministrarContenido.js
+++ b/vista/app/src/components/AdministrarContenido.js
@@ -44,7 +44,7 @@ class AdministrarContenido extends Component {
     const {modalOpen} = this.state;
     const {modalTitle, contenidoProps, FormElement, formElementProps, mostrarContenido} = this.props;
     return (
-      <div className={mostrarContenido !== "undefined" ? mostrarContenido ? 'show' : "hide" : ''}>
+      <div className={mostrarContenido ? 'show' : "hide"}>
         <Contenido
           {...contenidoProps}
           onAgregar={this.toggleModal}

--- a/vista/app/src/containers/AdministrarCancionesContainer.js
+++ b/vista/app/src/containers/AdministrarCancionesContainer.js
@@ -78,7 +78,7 @@ class AdministrarCancionesContainer extends Component {
   }
 
   render () {
-    const {canciones} = this.props;
+    const {canciones, mostrar} = this.props;
     return (
       <AdministrarContenido 
         FormElement={AltaCancion}
@@ -90,6 +90,7 @@ class AdministrarCancionesContainer extends Component {
           ...this.state.cancion,
           audio: this.state.audio
         }}
+        mostrarContenido={mostrar}
         modalTitle={this.state.editando === null ? 'Alta Cancion' : 'Actualizar Canción'}
         contenidoProps={{
           onEliminar: this.onEliminar,

--- a/vista/app/src/containers/AdministrarContenidoContainer.js
+++ b/vista/app/src/containers/AdministrarContenidoContainer.js
@@ -13,22 +13,41 @@ import AdministrarAlbumes from './AdminsitrarAlbumesContainer';
 const TabPane = Tabs.TabPane;
 
 class AdministrarContenidoContainer extends Component {
-  
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      estados: [
+        {key: "1", estado: true},
+        {key: "2", estado: false},
+        {key: "3", estado: false},
+        {key: "4", estado: false},
+      ]
+    };
+  }
+
+  onChangeHandler = (currentTab) => {
+    let {estados} = this.state;
+    estados.map((e) => e.estado = e.key === currentTab);
+    this.setState({estados});
+  }
+
   render () {
+    const {estados} = this.state;
     return (
       <PerfilWrapper>
-        <Tabs className={'full-height bg-color-white table-container'}>
+        <Tabs className={'full-height bg-color-white table-container administrarTabs'} onChange={this.onChangeHandler}>
           <TabPane tab="Canciones" key="1">
-            <AdministrarCanciones />
+            <AdministrarCanciones mostrar={estados[0].estado}/>
           </TabPane>
           <TabPane tab="Discos" key="2">
-            <AdministrarDiscos />
+            <AdministrarDiscos mostrar={estados[1].estado}/>
           </TabPane>
           <TabPane tab="Albumes" key="3">
-            <AdministrarAlbumes />
+            <AdministrarAlbumes mostrar={estados[2].estado}/>
           </TabPane>
           <TabPane tab="Eventos" key="4">
-            <AdministrarEventos />
+            <AdministrarEventos mostrar={estados[3].estado}/>
           </TabPane>
         </Tabs>
       </PerfilWrapper>

--- a/vista/app/src/containers/AdministrarDiscosContainer.js
+++ b/vista/app/src/containers/AdministrarDiscosContainer.js
@@ -82,7 +82,7 @@ class AdministrarCancionesContainer extends Component {
   }
 
   render () {
-    const {discos, canciones} = this.props;
+    const {discos, canciones, mostrar} = this.props;
     if (!canciones.length) return (<div>{'Debe crear una canción antes de poder operar con discos'}</div>);
     return (
       <AdministrarContenido 
@@ -96,6 +96,7 @@ class AdministrarCancionesContainer extends Component {
           portada: this.state.portada,
           ...this.state.disco
         }}
+        mostrarContenido={mostrar}
         modalTitle={this.state.editando === null ? 'Alta Disco' : 'Actualizar Disco'}
         contenidoProps={{
           onEliminar: this.onEliminar,

--- a/vista/app/src/containers/AdministrarEventosContainer.js
+++ b/vista/app/src/containers/AdministrarEventosContainer.js
@@ -85,7 +85,7 @@ class AdministrarEventosContainer extends Component {
   }
 
   render () {
-    const {eventos} = this.props;
+    const {eventos, mostrar} = this.props;
     return (
       <AdministrarContenido 
         FormElement={AltaEvento}
@@ -97,6 +97,7 @@ class AdministrarEventosContainer extends Component {
           eventos: mapContentName(eventos, this.state.editando),
           ...this.state.evento
         }}
+        mostrarContenido={mostrar}
         modalTitle={this.state.editando === null ? 'Alta Evento' : 'Actualizar Evento'}
         contenidoProps={{
           onEliminar: this.onEliminar,

--- a/vista/app/src/containers/AdminsitrarAlbumesContainer.js
+++ b/vista/app/src/containers/AdminsitrarAlbumesContainer.js
@@ -74,7 +74,7 @@ class AdministrarCancionesContainer extends Component {
   }
 
   render () {
-    const {albumes, discos} = this.props;
+    const {albumes, discos, mostrar} = this.props;
     if (!discos.length) return (<div>{'Debe crear una canción antes de poder operar con discos'}</div>);
     return (
       <AdministrarContenido 
@@ -88,6 +88,7 @@ class AdministrarCancionesContainer extends Component {
           portada: this.state.portada,
           ...this.state.album
         }}
+        mostrarContenido={mostrar}
         modalTitle={this.state.editando === null ? 'Alta Album' : 'Actualizar Album'}
         contenidoProps={{
           onEliminar: this.onEliminar,

--- a/vista/app/src/styles/AdministrarContenido.scss
+++ b/vista/app/src/styles/AdministrarContenido.scss
@@ -4,3 +4,15 @@
   max-height: $content-max-height;
   overflow-y: auto;
 }
+
+.administrarTabs {
+  overflow-y: scroll;
+}
+
+.administrarTabs .show {
+  display: block;
+}
+
+.administrarTabs .hide {
+  display: none;
+}

--- a/vista/app/src/styles/AdministrarContenido.scss
+++ b/vista/app/src/styles/AdministrarContenido.scss
@@ -6,7 +6,7 @@
 }
 
 .administrarTabs {
-  overflow-y: scroll;
+  overflow-y: scroll !important;
 }
 
 .administrarTabs .show {


### PR DESCRIPTION
Tuve que hacer todo este lio porque el contenedor de los tabs es el que tiene el overflow y pasaba que siempre tiene el alto de la lista mas larga, lo que hacia que al ir a una entidad con dos registros me aparezca una scroll-bar larguisima sin ningún sentido.